### PR TITLE
SPIFFSEditor.h Removed from EvilCrow-RFv2.ino in v1.3.3

### DIFF
--- a/firmware/v1.3/EvilCrow-RFv2/EvilCrow-RFv2.ino
+++ b/firmware/v1.3/EvilCrow-RFv2/EvilCrow-RFv2.ino
@@ -4,7 +4,6 @@
 #include <AsyncTCP.h>
 #include <ESPAsyncWebServer.h>
 #include <AsyncElegantOTA.h>
-#include <SPIFFSEditor.h>
 #include <EEPROM.h>
 #include "SPIFFS.h"
 #include "SPI.h"


### PR DESCRIPTION
I removed "**SPIFFSEditor.h**" from **EvilCrow-RFv2.ino** file in version 1.3.3 to compile code without error.